### PR TITLE
[EN-1013] Updating bridge breaks export with unity mono

### DIFF
--- a/.build/files/Bridge.Min.targets
+++ b/.build/files/Bridge.Min.targets
@@ -13,9 +13,9 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <BridgeNetCompilerTarget Condition="$(OnWin) == true">BridgeNetCompilerTask</BridgeNetCompilerTarget>
-    <BridgeNetCompilerTarget Condition="$(OnWin) != true">BridgeNetCompilerUtil</BridgeNetCompilerTarget>
-    <BridgeNetCompilerTarget Condition="$(OnWin) != true And $(MSBuildToolsPath.Contains('msbuild'))">BridgeNetCompilerTask</BridgeNetCompilerTarget>
+    <BridgeNetCompilerTarget>BridgeNetCompilerUtil</BridgeNetCompilerTarget>
+    <BridgeNetCompilerTarget Condition="$(MSBuildToolsPath.Contains('MSBuild'))">BridgeNetCompilerTask</BridgeNetCompilerTarget>
+    <BridgeNetCompilerTarget Condition="$(MSBuildToolsPath.Contains('msbuild'))">BridgeNetCompilerTask</BridgeNetCompilerTarget>
     <PrepareForRunDependsOn>$(PrepareForRunDependsOn);$(BridgeNetCompilerTarget)</PrepareForRunDependsOn>
   </PropertyGroup>
 
@@ -44,10 +44,11 @@
     <Message Text="BridgeNetCompilerUtil started: Project: $(MSBuildProjectName)" Importance="high" />
 
     <PropertyGroup>
+      <MonoPath>mono</MonoPath>
+      <MonoPath Condition="$(UNITY_MONO_PATH) != ''">$(UNITY_MONO_PATH)</MonoPath>
       <BridgeUtilWorkDir>$(MSBuildThisFileDirectory)\..\tools\</BridgeUtilWorkDir>
       <BridgePath>$(MSBuildProjectDirectory)\$(OutDir)\Bridge.dll</BridgePath>
-      <BridgeUtilCommand>&quot;$(BridgeUtilWorkDir)bridge.exe&quot; -p &quot;$(MSBuildProjectFullPath)&quot; -b &quot;$(BridgePath)&quot; --settings AssemblyName:&quot;$(AssemblyName)&quot;,Configuration:&quot;$(Configuration)&quot;,DefineConstants:&quot;$(DefineConstants)&quot;,OutputPath:&quot;$(OutputPath)&quot;,OutDir:&quot;$(OutDir)&quot;,OutputType:&quot;$(OutputType)&quot;,Platform:&quot;$(Platform)&quot;,RootNamespace:&quot;$(RootNamespace)&quot;</BridgeUtilCommand>
-      <BridgeUtilCommand Condition="$(OnWin) != true">mono $(BridgeUtilCommand)</BridgeUtilCommand>
+      <BridgeUtilCommand>&quot;$(MonoPath)&quot; &quot;$(BridgeUtilWorkDir)bridge.exe&quot; -p &quot;$(MSBuildProjectFullPath)&quot; -b &quot;$(BridgePath)&quot; --settings AssemblyName:&quot;$(AssemblyName)&quot;,Configuration:&quot;$(Configuration)&quot;,DefineConstants:&quot;$(DefineConstants)&quot;,OutputPath:&quot;$(OutputPath)&quot;,OutDir:&quot;$(OutDir)&quot;,OutputType:&quot;$(OutputType)&quot;,Platform:&quot;$(Platform)&quot;,RootNamespace:&quot;$(RootNamespace)&quot;</BridgeUtilCommand>
     </PropertyGroup>
 
     <Message Text="   Working Directory:           $(BridgeUtilWorkDir)" Importance="high" />


### PR DESCRIPTION
I made this change to Bridge.Min.targets in pipeline and not bridge itself, hence on update it is reset.

A reminder of the change: 

Use compiler task to build regardless of platform if using msbuild, otherwise use the util command, if using the latter then replace 'mono' with UNITY_MONO_PATH if it is set.